### PR TITLE
Remove subsitutions as per markedjs/marked#1532

### DIFF
--- a/src/marked.ts
+++ b/src/marked.ts
@@ -119,8 +119,6 @@ export class Marked {
     src = src
       .replace(/\r\n|\r/g, "\n")
       .replace(/\t/g, "    ")
-      .replace(/\u00a0/g, " ")
-      .replace(/\u2424/g, "\n")
       .replace(/^ +$/gm, "");
 
     return BlockLexer.lex(src, options, true);


### PR DESCRIPTION
I got bitten by this today; the `\u00a0` character should not be substituted for `\u0020`. The grandparent markedjs lib removed this substitution some time ago:

- https://github.com/markedjs/marked/pull/1532/files
- https://github.com/markedjs/marked/pull/897#issuecomment-451443207

There also don't appear to be any tests in this lib? Happy to add some if required but with no project-level infra, I feel that's best left to maintainers to make decisions about.