### PR TITLE
Fix YAML load to be compatible with deno_std@0.180

### DIFF
--- a/src/block-lexer.ts
+++ b/src/block-lexer.ts
@@ -22,7 +22,7 @@ import {
   Obj
 } from "./interfaces.ts";
 import { Marked } from "./marked.ts";
-import { load } from "https://deno.land/std/encoding/_yaml/loader/loader.ts";
+import { load } from "https://deno.land/std/yaml/_loader/loader.ts";
 
 export class BlockLexer<T extends typeof BlockLexer> {
   static simpleRules: RegExp[] = [];


### PR DESCRIPTION
Due to this change: https://github.com/denoland/deno_std/pull/3251/files#diff-c9270af977b3c2b389473bf7d003f3c46bfc1bec6cb621b6f645851d83d00b65